### PR TITLE
changed webpack config for production

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -2,11 +2,14 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 
+const isProduction = process.env.NODE_ENV === 'production';
+
 module.exports = {
   entry: './src/script.js', // your entry point
   output: {
-    filename: 'script.js',
-    path: path.resolve(__dirname, 'dist')
+    filename: isProduction ? 'script.[contenthash].js' : 'script.js', // ✨ Added [contenthash]
+    path: path.resolve(__dirname, 'dist'),
+    clean: true // ✨ Automatically clean dist/ before each build
   },
   plugins: [
     new HtmlWebpackPlugin({
@@ -36,9 +39,9 @@ module.exports = {
       }
     ]
   },
-  mode: 'development', // or 'production'
-  devtool: 'eval-source-map',
-  watch: true, // Enable watch mode
+  mode: isProduction ? 'production' : 'development',
+  devtool: isProduction ? 'hidden-source-map' : 'eval-source-map',
+  watch: !isProduction, // Watch files ONLY in development
   devServer: {
     static: './dist',
     open: true,


### PR DESCRIPTION
Looks good! Here are the reasons why we changed the configuration:

- `watch: true` tells Webpack to keep watching for file changes forever — it never finishes the build. Netlift deployment fails. Netlify expects npm run build to finish so it can deploy the output. Only set this in development. 
- Hashing: Allows browser to know when a file changes. If your JavaScript changes → filename changes automatically → browser will always fetch the new file. `[contenthash]` A file-specific hash based on only that file's content. Only changes when that file changes. `[hash]` - A global hash of the entire build. Changes whenever any change anywhere in your project.
- Added `clean: true` — Webpack will automatically delete old dist/ files before every new build, so your output is always fresh and clean.

When you generate a source-map in production, Webpack creates a .map file (e.g., script.abcd1234.js.map) and puts it in your dist/ folder.
- `hidden-source-map`: Webpack builds source maps but does NOT link to them automatically in your JS